### PR TITLE
support white space before span control characters

### DIFF
--- a/mdx_tableau/parser.py
+++ b/mdx_tableau/parser.py
@@ -124,7 +124,11 @@ def maybe_modifiers(row):
 
 
 def span_modifier(row):
-    return row.scan(r'[{^]')
+    m = row.scan(r'\s*([{^])')
+    if m:
+        return m.strip()
+    else:
+        return None
 
 def modifiers(row, kind):
     result = []

--- a/tests/test_tableau_parse.py
+++ b/tests/test_tableau_parse.py
@@ -240,6 +240,18 @@ class TestTableauParse(unittest.TestCase):
             [ c("", { "span": "^"}), c("e") ],
         ])
 
+    def test_single_rowspan_with_space(self):
+        block = "\n".join([
+                    "| a | b |",
+                    "| ^ | e |",
+                ])
+
+        result = tableau.to_ast(block)
+        self.assertResult(result, [ 
+            [ c("a"), c("b") ],
+            [ c("", { "span": "^"}), c("e") ],
+        ])
+
     def test_single_colspan(self):
         block = "\n".join([
                     "| a | b |",
@@ -247,7 +259,19 @@ class TestTableauParse(unittest.TestCase):
                 ])
 
         result = tableau.to_ast(block)
-        self.assertResult(result, [ 
+        self.assertResult(result, [
+            [ c("a"), c("b") ],
+            [ c("d"), c("e", { "span": "{"})]
+        ])
+
+    def test_single_colspan_with_space(self):
+        block = "\n".join([
+                    "| a | b  |",
+                    "| d | {e |",
+                ])
+
+        result = tableau.to_ast(block)
+        self.assertResult(result, [
             [ c("a"), c("b") ],
             [ c("d"), c("e", { "span": "{"})]
         ])


### PR DESCRIPTION
Even if column has space before ^ or {, then
that column treats as span column.